### PR TITLE
Update call to TensorRT context executor

### DIFF
--- a/depth.py
+++ b/depth.py
@@ -161,7 +161,7 @@ class DepthEngine:
         
         # Copy the input to the GPU, execute the inference, and copy the output back to the CPU
         cuda.memcpy_htod_async(self.d_input, self.h_input, self.cuda_stream)
-        self.context.execute_async_v2(bindings=[int(self.d_input), int(self.d_output)], stream_handle=self.cuda_stream.handle)
+        self.context.execute_v2(bindings=[int(self.d_input), int(self.d_output)])
         cuda.memcpy_dtoh_async(self.h_output, self.d_output, self.cuda_stream)
         self.cuda_stream.synchronize()
         


### PR DESCRIPTION
The function for `trt.context.execute_async_v2` has been renamed to `trt.context.execute_v2` and the signature has changed.  I didn't investigate too much but supplying the same args to `trt.context.execute_async_v3` resulted in this error

```
[01/25/2025-17:25:05] [TRT] [E] IExecutionContext::enqueueV3: Error Code 3: API Usage Error (Parameter check failed, condition: mContext.profileObliviousBindings.at(profileObliviousIndex) != nullptr. Address is not set for input tensor input. Call setInputTensorAddress or setTensorAddress before enqueue/execute.)
```

Dev environment:

Running in a container `nvcr.io/nvidia/pytorch:24.12-py3-igpu`, Orin Nano, Jetpack 6.2

```
# pip freeze | grep -E 'tensor|torch'

apex @ file:///opt/pytorch/apex/dist/apex-0.1-cp312-cp312-linux_aarch64.whl#sha256=62d384f118d3f106bbe769b044a8687bd92ac8935410915b20ba572fcc68f64e
jupyterlab_tensorboard_pro @ file:///opt/pytorch/jupyterlab_tensorboard_pro_wheel/jupyterlab_tensorboard_pro-4.0.0-py2.py3-none-any.whl#sha256=516cd227da3e052fc0c0e81a6c2006d095c21e16814189746917d97000047696
nvidia-cudnn-frontend @ file:///opt/pytorch/lightning-thunder/tmp/cudnn_frontend
onnx @ file:///opt/pytorch/pytorch/third_party/onnx
pytorch-triton @ file:///tmp/dist/pytorch_triton-3.0.0%2Bdedb7bdf3-cp312-cp312-linux_aarch64.whl#sha256=781d981abf5e0743c45fb4532270ed35ab0c9467239879633441e98404bbc0b1
safetensors==0.4.5
tensorboard==2.16.2
tensorboard-data-server==0.7.2
tensorrt @ file:///workspace/TensorRT-10.7.0.23/python/tensorrt-10.7.0-cp312-none-linux_aarch64.whl#sha256=60e975db13ccc26b269bb63c57584435e11c9c0b91cbd4d7d91c12f4de8baddc
torch @ file:///opt/transfer/torch-2.6.0a0%2Bdf5bbc09d1.nv24.12-cp312-cp312-linux_aarch64.whl#sha256=c92a4cd8d5edc79deaf946a4dc8d11734a2b3d1396d0468c8a81e70d7f588227
torch_tensorrt @ file:///opt/pytorch/torch_tensorrt/dist/torch_tensorrt-2.6.0a0-cp312-cp312-linux_aarch64.whl#sha256=ee1dea76252aa33f8d061e2d79d008a5a3af7c5ef54bd2bb979ab5b00aed351d
torchprofile==0.0.4
torchvision @ file:///opt/transfer/torchvision-0.20.0a0-cp312-cp312-manylinux_2_34_aarch64.whl#sha256=adf4b40cd06bdf4d137c791d1f8fe1355db386fdd6fc95a9a90cd2e1a90e948a
```

